### PR TITLE
Add cryptographically secure random number generator 

### DIFF
--- a/betterguid.go
+++ b/betterguid.go
@@ -1,6 +1,8 @@
 package betterguid
 
 import (
+	cryptorand "crypto/rand"
+	"math/big"
 	"math/rand"
 	"sync"
 	"time"
@@ -23,6 +25,8 @@ var (
 	rnd           *rand.Rand
 )
 
+var Cryptographic bool
+
 func init() {
 	// seed to get randomness
 	rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -30,7 +34,16 @@ func init() {
 
 func genRandPart() {
 	for i := 0; i < len(lastRandChars); i++ {
-		lastRandChars[i] = rnd.Intn(64)
+		if Cryptographic {
+			n, err := cryptorand.Int(cryptorand.Reader, big.NewInt(64))
+			if err != nil {
+				lastRandChars[i] = rnd.Intn(64)
+			} else {
+				lastRandChars[i] = int(n.Int64())
+			}
+		} else {
+			lastRandChars[i] = rnd.Intn(64)
+		}
 	}
 }
 

--- a/betterguid.go
+++ b/betterguid.go
@@ -25,6 +25,7 @@ var (
 	rnd           *rand.Rand
 )
 
+// Set this flag to true if you need to use a cryptographically secure PRNG
 var Cryptographic bool
 
 func init() {

--- a/betterguid_test.go
+++ b/betterguid_test.go
@@ -30,6 +30,11 @@ func Test(t *testing.T) {
 	}
 }
 
+func TestCrypto(t *testing.T) {
+	Cryptographic = true
+	Test(t)
+}
+
 func doMany(t *testing.T, wg *sync.WaitGroup) {
 	ids := make(map[string]bool)
 	prev := ""
@@ -57,4 +62,9 @@ func TestMany(t *testing.T) {
 		go doMany(t, &wg)
 	}
 	wg.Wait()
+}
+
+func TestManyCrypto(t *testing.T) {
+	Cryptographic = true
+	TestMany(t)
 }


### PR DESCRIPTION
Hi

I saw issue #5, and agreed that it is a good idea, and not too hard to implement.

Some applications may have to use a cryptographically secure PRNG as a requirement imposed by regulations, others want to use one because they consider it to be good practice. I fall into the latter category.

My change would make it possible to use the secure PRNG by setting a global package flag.